### PR TITLE
Atributo obsoleto

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,8 +100,9 @@
 
       </div>
       <div class="col-sm-4">
+        <!--atributo obsoleto-->
         <iframe id="spotify-pl" src="https://open.spotify.com/embed/playlist/2R79kvnRMhxE5DO1KUQFCj" width="230"
-          height="100" allowtransparency="true" allow="encrypted-media"></iframe> </div>
+          height="100" <!--[if IE] allowTransparency="true" --> allow="encrypted-media"></iframe> </div>
     </div>
     <!-- Education Section -->
     <div class="education" id="education">


### PR DESCRIPTION
Dani el atributo allowtransparency es obsoleto según el verificador de w3.